### PR TITLE
Add macOS support on CocoaPods

### DIFF
--- a/LatLongToTimezone.podspec
+++ b/LatLongToTimezone.podspec
@@ -64,11 +64,8 @@ Uses polygonal regions with accuracy at worst ~2km.  Works entirely offline.
   #  the deployment target. You can optionally include the target after the platform.
   #
 
-  s.platform     = :ios, "8.0"
-
-  #  When using multiple platforms
-  # s.ios.deployment_target = "5.0"
-  # s.osx.deployment_target = "10.7"
+  s.ios.deployment_target = "8.0"
+  s.osx.deployment_target = "10.9"
   # s.watchos.deployment_target = "2.0"
   # s.tvos.deployment_target = "9.0"
 


### PR DESCRIPTION
The Swift code compiles without changes, but the podspec doesn't declare support for macOS.