### PR TITLE
Update version of org.jetbrains.annotataions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>15.0</version>
+            <version>16.0.3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
The version 15.0 of org.jetbrains.annotations has a vulnerability reported by the OWASP dependency checker: https://nvd.nist.gov/vuln/detail/CVE-2017-8316. The vulnerability is gone in the new version 16.0.3.