### PR TITLE
Set carthage project min ios version to 9.1

### DIFF
--- a/carthage/LatLongToTimezone.xcodeproj/project.pbxproj
+++ b/carthage/LatLongToTimezone.xcodeproj/project.pbxproj
@@ -256,7 +256,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = LatLongToTimezone/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -281,7 +281,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = LatLongToTimezone/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
Today when installing with carthage, project comes with a min deployment version of iOS 12, which is really high :) the projects compiles fine with iOS 9.1 so I got that down to make it compatible with a lot more devices (and therefore projects).